### PR TITLE
Add GitHub Action to validate integration with hassfest

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v2"
+        - uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
Create hassfest.yaml to add GitHub Action validate the integration with hassfest

https://developers.home-assistant.io/blog/2020/04/16/hassfest/

See example in https://github.com/zha-ng/zha-map/pull/18

https://github.com/zha-ng/zha-map/pull/18/commits/ffecf7738561ae3aec4c6a9b71fea7175a1d5839